### PR TITLE
navbar-text style updated for the small devices

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -177,6 +177,10 @@ footer {
 		height: 30px;
 		width: 30px;
 	}
+	.navbar-text{
+		display: block;
+		margin:15px 100px;
+	}
 	.landing-text h1 h3 h4 {
 		font-size: 300%;
 	}


### PR DESCRIPTION
In the previous version nav-bar text was overlapping on the icon in small devices but now it has been removed.